### PR TITLE
fix: remove console.log that interfered with GitHub Actions output

### DIFF
--- a/.github/scripts/claude-code-review.cjs
+++ b/.github/scripts/claude-code-review.cjs
@@ -244,7 +244,6 @@ If no significant issues are found, acknowledge the code quality and provide 1-2
       ];
 
       // Call Claude API
-      console.log('Calling Claude API for code review...');
       const response = await this.callClaude(messages, systemPrompt);
 
       // Format final comment


### PR DESCRIPTION
## Summary
The 'Calling Claude API...' log was writing to stdout and corrupting the structured output format expected by GitHub Actions.

## Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
