### PR TITLE
Fix Claude review script large diff truncation issue

### DIFF
--- a/.github/claude-review-config.json
+++ b/.github/claude-review-config.json
@@ -4,7 +4,7 @@
     "sonnet": "claude-3-5-sonnet-20241022"
   },
   "maxTokens": 4000,
-  "maxInputTokens": 6000,
+  "maxInputTokens": 2000,
   "includePatterns": [
     "**/*.ts",
     "**/*.js",

--- a/.github/scripts/claude-code-review.cjs
+++ b/.github/scripts/claude-code-review.cjs
@@ -162,7 +162,7 @@ If no significant issues are found, acknowledge the code quality and provide 1-2
   /**
    * Truncate diff if it exceeds token limits
    */
-  truncateDiff(diff, maxInputTokens = 6000) {
+  truncateDiff(diff, maxInputTokens = 2000) {
     const estimatedTokens = this.estimateTokens(diff);
 
     if (estimatedTokens <= maxInputTokens) {
@@ -232,7 +232,8 @@ If no significant issues are found, acknowledge the code quality and provide 1-2
       }
 
       // Handle large diffs
-      const { diff: finalDiff, ...truncationInfo } = this.truncateDiff(processedDiff);
+      const maxInputTokens = config.maxInputTokens || 2000; // Use config value or default to 2000
+      const { diff: finalDiff, ...truncationInfo } = this.truncateDiff(processedDiff, maxInputTokens);
 
       // Generate prompts
       const systemPrompt = this.generateSystemPrompt();


### PR DESCRIPTION
## Summary

Fixes the Claude AI code review script failing with 'unexpected end of data' JSON parsing errors when processing large diffs.

## Root Cause

The diff from the cleanup branch was ~205KB (51,000+ tokens), which exceeded Claude API's request size limits. The script was trying to send the entire diff in the JSON request before truncation could occur.

## Changes

- Reduce `maxInputTokens` default from 6000 to 2000 tokens  
- Update config file to use 2000 token limit
- Pass config `maxInputTokens` to `truncateDiff` method properly
- This ensures large diffs are truncated before being sent to Claude API

## Test Plan

- [x] Script changes made and committed
- [ ] Test on PR 19 with `/claude-review` command to verify fix

🤖 Generated with [Claude Code](https://claude.ai/code)