### PR TITLE
Add debugging to Claude review script for JSON parsing issues

### DIFF
--- a/.github/claude-review-config.json
+++ b/.github/claude-review-config.json
@@ -4,7 +4,7 @@
     "sonnet": "claude-3-5-sonnet-20241022"
   },
   "maxTokens": 4000,
-  "maxInputTokens": 2000,
+  "maxInputTokens": 500,
   "includePatterns": [
     "**/*.ts",
     "**/*.js",

--- a/.github/scripts/claude-code-review.cjs
+++ b/.github/scripts/claude-code-review.cjs
@@ -27,12 +27,14 @@ class ClaudeCodeReviewer {
    * Make a request to Claude API
    */
   async callClaude(messages, systemPrompt) {
-    const data = JSON.stringify({
+    const requestBody = {
       model: this.config.model,
       max_tokens: this.config.maxTokens,
       system: systemPrompt,
       messages: messages,
-    });
+    };
+    const data = JSON.stringify(requestBody);
+    console.error(`DEBUG: JSON request size: ${data.length} chars`);
 
     const options = {
       hostname: 'api.anthropic.com',
@@ -245,6 +247,7 @@ If no significant issues are found, acknowledge the code quality and provide 1-2
       ];
 
       // Call Claude API
+      console.error(`DEBUG: About to call Claude with diff size: ${finalDiff.length} chars, estimated tokens: ${truncationInfo.truncatedTokens || truncationInfo.originalTokens}`);
       const response = await this.callClaude(messages, systemPrompt);
 
       // Format final comment


### PR DESCRIPTION
## Summary

Adds debugging output to the Claude review script to help diagnose the persistent JSON parsing errors.

## Root Cause Investigation

Even with truncation fixes, we're still getting:
```
Claude API error: The request body is not valid JSON: unexpected end of data: line 1 column 7986 (char 7985)
```

## Debug Changes

- **More aggressive truncation**: Reduce `maxInputTokens` from 2000 to 500 tokens
- **Diff size logging**: Log diff length and estimated tokens before API call
- **JSON size logging**: Log actual JSON request size to see if it's still too large

## Expected Results

This will help identify:
1. If the issue is still request size (should be much smaller now)
2. If there are special characters corrupting the JSON
3. The actual payload sizes being sent to Claude API

## Test Plan

- [ ] Test on PR 22 with `/claude-review` to get debug output
- [ ] Analyze debug logs to identify root cause
- [ ] Implement proper fix based on findings

🤖 Generated with [Claude Code](https://claude.ai/code)