### PR TITLE
Fix UTF-8 encoding issue and restore reasonable token limit

### DIFF
--- a/.github/claude-review-config.json
+++ b/.github/claude-review-config.json
@@ -4,7 +4,7 @@
     "sonnet": "claude-3-5-sonnet-20241022"
   },
   "maxTokens": 4000,
-  "maxInputTokens": 500,
+  "maxInputTokens": 2000,
   "includePatterns": [
     "**/*.ts",
     "**/*.js",

--- a/.github/scripts/claude-code-review.cjs
+++ b/.github/scripts/claude-code-review.cjs
@@ -52,12 +52,16 @@ class ClaudeCodeReviewer {
     return new Promise((resolve, reject) => {
       const req = https.request(options, (res) => {
         let responseData = '';
+        
+        // Set encoding to handle UTF-8 properly
+        res.setEncoding('utf8');
 
         res.on('data', (chunk) => {
           responseData += chunk;
         });
 
         res.on('end', () => {
+          console.error(`DEBUG: Response size: ${responseData.length} chars, ends with: "${responseData.slice(-50)}"`);
           try {
             const parsed = JSON.parse(responseData);
             if (res.statusCode >= 400) {


### PR DESCRIPTION
- Set proper UTF-8 encoding on HTTP response stream to prevent JSON corruption
- Restore maxInputTokens from 500 back to 2000 for practical use
- Keep debug logging to verify the fix works
- This should resolve the 'unexpected end of data' JSON parsing errors

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

Brief description of what this PR does.

## Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

