### PR TITLE
fix truncation of diff

### DIFF
--- a/.github/claude-review-config.json
+++ b/.github/claude-review-config.json
@@ -3,8 +3,8 @@
     "default": "claude-3-haiku-20240307",
     "sonnet": "claude-3-5-sonnet-20241022"
   },
-  "maxTokens": 4000,
-  "maxInputTokens": 2000,
+  "maxTokens": 8000,
+  "maxInputTokens": 100000,
   "includePatterns": [
     "**/*.ts",
     "**/*.js",


### PR DESCRIPTION
## Summary

Fix Claude review system: remove diff truncation and increase token limits

- Remove diff truncation that was causing malformed JSON and incomplete reviews
- Increase maxInputTokens from 2000 to 100000 to handle full PRs
- Increase maxTokens from 4000 to 8000 for more detailed reviews
- Replace truncateDiff with checkDiffSize that warns but doesn't truncate
- Now Claude can review the complete diff for thorough code analysis

## Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
