### PR TITLE
fix the content-length for the Claude request

### DIFF
--- a/.github/scripts/claude-code-review.cjs
+++ b/.github/scripts/claude-code-review.cjs
@@ -35,9 +35,6 @@ class ClaudeCodeReviewer {
     };
     const data = JSON.stringify(requestBody);
 
-    console.error(`DEBUG: body length ${data.length}: """\n${data}\n"""\n`)
-    console.error(`DEBUG body byte length: ${Buffer.byteLength(data, 'utf8')}`)
-
     const options = {
       hostname: 'api.anthropic.com',
       port: 443,
@@ -45,7 +42,7 @@ class ClaudeCodeReviewer {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': data.length,
+        'Content-Length': Buffer.byteLength(data, 'utf8'),
         'x-api-key': this.apiKey,
         'anthropic-version': '2023-06-01',
       },


### PR DESCRIPTION
## Summary

used the utf8 byte length, not the length of the string

## Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
