### PR TITLE
fixed the hard-coded default to docx

### DIFF
--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -48,7 +48,7 @@ function shouldUseDeterministicTimestamps(directory) {
 
     // Also check for TESTING environment variable
     return process.env.NODE_ENV === 'test' || process.env.TESTING === 'true';
-  } catch (error) {
+  } catch {
     // If we can't read config, default to real timestamps
     return false;
   }

--- a/src/cli/commands/format.ts
+++ b/src/cli/commands/format.ts
@@ -49,13 +49,13 @@ export async function formatCommand(
   const format = options.format || defaultFormat;
 
   console.log(`Formatting collection: ${collectionId}`);
-  console.log(`Format: ${format}`);
   if (options.artifacts && options.artifacts.length > 0) {
     console.log(`Artifacts: ${options.artifacts.join(', ')}`);
   } else {
     console.log(`Artifacts: all available`);
   }
   console.log(`Location: ${collection.path}`);
+  console.log(`Format: ${format}`);
 
   try {
     // Execute format action with optional artifact filtering

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -188,7 +188,7 @@ program
   .argument('<workflow>', 'Workflow name (e.g., job, blog)')
   .argument('<collection_id>', 'Collection ID to format')
   .argument('[artifacts...]', 'Optional artifact names to format (e.g., resume, cover_letter)')
-  .option('-f, --format <format>', 'Output format (docx, html, pdf)', 'docx')
+  .option('-f, --format <format>', 'Output format (docx, html, pdf)')
   .action(
     withErrorHandling(async (workflow, collectionId, artifacts, options) => {
       await formatCommand(workflow, collectionId, {


### PR DESCRIPTION
## Summary

don't default to docx for all formats, let the workflow specify the default

## Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Test Plan

- [x] Unit tests pass (`npm test`)
- [x] E2E tests pass (`npm run test:e2e:snapshots`)
- [x] Preflight check passes (`pnpm preflight`)
- [x] Manual testing completed

## Notes

Any additional context or notes for reviewers.
